### PR TITLE
Feat/add global discounts

### DIFF
--- a/i18n/es_VE.po
+++ b/i18n/es_VE.po
@@ -6,14 +6,29 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-19 15:08+0000\n"
-"PO-Revision-Date: 2024-03-19 15:08+0000\n"
+"POT-Creation-Date: 2025-07-04 19:55+0000\n"
+"PO-Revision-Date: 2025-07-04 19:55+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: tribute_fields
+#: model_terms:ir.ui.view,arch_db:tribute_fields.res_config_settings_view_form_inherit_tribute_fields
+msgid "<span class=\"fa fa-lg fa-building-o\" title=\"Fiscal Currency\"/>"
+msgstr "<span class=\"fa fa-lg fa-building-o\" title=\"Moneda fiscal\"/>"
+
+#. module: tribute_fields
+#: model_terms:ir.ui.view,arch_db:tribute_fields.res_config_settings_view_form_inherit_tribute_fields
+msgid "<span class=\"fa fa-lg fa-building-o\" title=\"Show Fiscal Fields\"/>"
+msgstr "<span class=\"fa fa-lg fa-building-o\" title=\"Mostrar campos fiscales\"/>"
+
+#. module: tribute_fields
+#: model:ir.model.fields.selection,name:tribute_fields.selection__res_company__invoice_print_method__both
+msgid "Both"
+msgstr "Ambos"
 
 #. module: tribute_fields
 #: model:ir.model,name:tribute_fields.model_res_company
@@ -23,7 +38,7 @@ msgstr "Compañías"
 #. module: tribute_fields
 #: model:ir.model,name:tribute_fields.model_res_config_settings
 msgid "Config Settings"
-msgstr "Opciones de configuración"
+msgstr "Ajustes de configuración"
 
 #. module: tribute_fields
 #: model:ir.model,name:tribute_fields.model_res_partner
@@ -38,10 +53,25 @@ msgid "Control Number"
 msgstr "Número de control"
 
 #. module: tribute_fields
+#: model:ir.model.fields,field_description:tribute_fields.field_account_bank_statement_line__amount_discount
+#: model:ir.model.fields,field_description:tribute_fields.field_account_move__amount_discount
+#: model:ir.model.fields,field_description:tribute_fields.field_account_payment__amount_discount
+msgid "Discount"
+msgstr "Descuento"
+
+#. module: tribute_fields
 #: model:ir.model.fields,field_description:tribute_fields.field_res_partner__ced_rif
 #: model:ir.model.fields,field_description:tribute_fields.field_res_users__ced_rif
 msgid "Document/RIF"
 msgstr "Cedula / RIF"
+
+#. module: tribute_fields
+#: model_terms:ir.ui.view,arch_db:tribute_fields.res_config_settings_view_form_inherit_tribute_fields
+msgid ""
+"Enable fields for the registration of the fiscal Control and Correlative "
+"Number"
+msgstr ""
+"Habilitar campos para el registro del Control Fiscal y Número Correlativo"
 
 #. module: tribute_fields
 #: model:ir.model.fields,field_description:tribute_fields.field_account_bank_statement_line__fiscal_correlative
@@ -49,6 +79,12 @@ msgstr "Cedula / RIF"
 #: model:ir.model.fields,field_description:tribute_fields.field_account_payment__fiscal_correlative
 msgid "Fiscal Correlative"
 msgstr "Correlativo fiscal"
+
+#. module: tribute_fields
+#: model:ir.model.fields,field_description:tribute_fields.field_res_company__fiscal_currency_id
+#: model:ir.model.fields,field_description:tribute_fields.field_res_config_settings__fiscal_currency_id
+msgid "Fiscal Currency"
+msgstr "Moneda fiscal"
 
 #. module: tribute_fields
 #: model_terms:ir.ui.view,arch_db:tribute_fields.inherited_base_partner_form
@@ -64,6 +100,34 @@ msgstr "Facturas fiscales"
 #: model:ir.ui.menu,name:tribute_fields.fiscal_reports_root_menu
 msgid "Fiscal Reports"
 msgstr "Informes fiscales"
+
+#. module: tribute_fields
+#: model:ir.model.fields.selection,name:tribute_fields.selection__res_company__invoice_print_method__fiscal_machine
+msgid "Fiscal machine"
+msgstr "Máquina fiscal"
+
+#. module: tribute_fields
+#: model:ir.model.fields.selection,name:tribute_fields.selection__res_company__invoice_print_method__free_form
+msgid "Free form"
+msgstr "Forma libre"
+
+#. module: tribute_fields
+#. odoo-python
+#: code:addons/tribute_fields/models/account_move.py:0
+#: code:addons/tribute_fields/models/account_move.py:0
+#: model:ir.model.fields,field_description:tribute_fields.field_account_bank_statement_line__global_discount
+#: model:ir.model.fields,field_description:tribute_fields.field_account_move__global_discount
+#: model:ir.model.fields,field_description:tribute_fields.field_account_payment__global_discount
+#, python-format
+msgid "Global Discount"
+msgstr "Descuento global"
+
+#. module: tribute_fields
+#: model:ir.model.fields,help:tribute_fields.field_account_bank_statement_line__global_discount
+#: model:ir.model.fields,help:tribute_fields.field_account_move__global_discount
+#: model:ir.model.fields,help:tribute_fields.field_account_payment__global_discount
+msgid "Global discount applied to the invoice, this is not a fiscal field"
+msgstr "Descuento global aplicado a la factura, este no es un campo fiscal"
 
 #. module: tribute_fields
 #: model:ir.model.fields,field_description:tribute_fields.field_account_bank_statement_line__fiscal_check
@@ -88,7 +152,7 @@ msgstr "Asiento contable"
 #: model:ir.model.fields,field_description:tribute_fields.field_res_partner__taxpayer_license
 #: model:ir.model.fields,field_description:tribute_fields.field_res_users__taxpayer_license
 msgid "LAE"
-msgstr "LAE"
+msgstr "Licencia de Actividad Económica"
 
 #. module: tribute_fields
 #: model:ir.model.fields,field_description:tribute_fields.field_res_company__municipality
@@ -101,6 +165,22 @@ msgid "No Fiscal Invoices"
 msgstr "Sin facturas fiscales"
 
 #. module: tribute_fields
+#: model:ir.model.fields,field_description:tribute_fields.field_account_bank_statement_line__num_report_z
+#: model:ir.model.fields,field_description:tribute_fields.field_account_move__num_report_z
+#: model:ir.model.fields,field_description:tribute_fields.field_account_payment__num_report_z
+msgid "Numero de reporte Z"
+msgstr "Número de reporte Z"
+
+#. module: tribute_fields
+#: model:ir.model.fields,field_description:tribute_fields.field_account_bank_statement_line__invoice_print_method
+#: model:ir.model.fields,field_description:tribute_fields.field_account_move__invoice_print_method
+#: model:ir.model.fields,field_description:tribute_fields.field_account_payment__invoice_print_method
+#: model:ir.model.fields,field_description:tribute_fields.field_res_company__invoice_print_method
+#: model:ir.model.fields,field_description:tribute_fields.field_res_config_settings__invoice_print_method
+msgid "Print Method"
+msgstr "Método de impresión"
+
+#. module: tribute_fields
 #: model:ir.model.fields,field_description:tribute_fields.field_res_company__ruc
 #: model:ir.model.fields,field_description:tribute_fields.field_res_partner__ruc
 #: model:ir.model.fields,field_description:tribute_fields.field_res_users__ruc
@@ -108,9 +188,18 @@ msgid "RUC"
 msgstr "RUC"
 
 #. module: tribute_fields
-#: model:ir.model.fields,field_description:tribute_fields.field_account_bank_statement_line__show_fiscal_fields
-#: model:ir.model.fields,field_description:tribute_fields.field_account_move__show_fiscal_fields
-#: model:ir.model.fields,field_description:tribute_fields.field_account_payment__show_fiscal_fields
+#: model_terms:ir.ui.view,arch_db:tribute_fields.res_config_settings_view_form_inherit_tribute_fields
+msgid "Select your fiscal currency for the impression of invoices"
+msgstr "Seleccione su moneda fiscal para la impresión de facturas"
+
+#. module: tribute_fields
+#: model:ir.model.fields,field_description:tribute_fields.field_account_bank_statement_line__fp_serial_num
+#: model:ir.model.fields,field_description:tribute_fields.field_account_move__fp_serial_num
+#: model:ir.model.fields,field_description:tribute_fields.field_account_payment__fp_serial_num
+msgid "Serial number FP"
+msgstr "Número de serie FP"
+
+#. module: tribute_fields
 #: model:ir.model.fields,field_description:tribute_fields.field_res_company__show_fiscal_fields
 #: model:ir.model.fields,field_description:tribute_fields.field_res_config_settings__show_fiscal_fields
 msgid "Show Fiscal Fields"
@@ -137,3 +226,25 @@ msgid ""
 msgstr ""
 "El correlativo fiscal y el número de control deben ser únicos, verifique los"
 " Siguientes documentos: %s"
+
+#. module: tribute_fields
+#. odoo-python
+#: code:addons/tribute_fields/models/account_move.py:0
+#, python-format
+msgid "The global discount cannot be negative."
+msgstr "El descuento global no puede ser negativo."
+
+#. module: tribute_fields
+#: model:ir.model.fields,field_description:tribute_fields.field_account_bank_statement_line__ticket_ref
+#: model:ir.model.fields,field_description:tribute_fields.field_account_move__ticket_ref
+#: model:ir.model.fields,field_description:tribute_fields.field_account_payment__ticket_ref
+msgid "Ticket reference"
+msgstr "Referencia de ticket"
+
+#. module: tribute_fields
+#. odoo-python
+#: code:addons/tribute_fields/models/account_move.py:0
+#: code:addons/tribute_fields/models/account_move.py:0
+#, python-format
+msgid "Untaxed Amount Without Discount"
+msgstr "Subtotal sin descuento"

--- a/models/account_move.py
+++ b/models/account_move.py
@@ -126,10 +126,10 @@ class AccountMove(models.Model):
 
             invoice.tax_totals["groups_by_subtotal"][aux_key] = invoice.tax_totals["groups_by_subtotal"].get(aux_key, []) + [{
                 "tax_group_name": _("Global Discount"),
-                "tax_group_amount": 10,
-                "tax_group_base_amount": 1,
-                "formatted_tax_group_amount": invoice.currency_id.format(10),
-                "formatted_tax_group_base_amount": invoice.currency_id.format(1),
+                "tax_group_amount": -10,
+                "tax_group_base_amount": -100,
+                "formatted_tax_group_amount": invoice.currency_id.format(-10),
+                "formatted_tax_group_base_amount": invoice.currency_id.format(-100),
                 "hide_base_amount": False
             }]
 

--- a/models/account_move.py
+++ b/models/account_move.py
@@ -24,6 +24,25 @@ class AccountMove(models.Model):
     ticket_ref = fields.Char("Ticket reference", readonly=True)
     fp_serial_num = fields.Char("Serial number FP", readonly=True)
     num_report_z = fields.Char("Numero de reporte Z", readonly=True)
+    global_discount = fields.Float("Global Discount", digits=(12, 2), default=0.0,
+        help="Global discount applied to the invoice, this is not a fiscal field")
+
+    @api.onchange("global_discount")
+    def _onchange_global_discount(self):
+        """
+        This method is used to apply a global discount to the invoice.
+        It will update the invoice lines with the global discount amount.
+        """
+        if self.global_discount < 0:
+            raise UserError(_("The global discount cannot be negative."))
+
+        if not self.invoice_line_ids:
+            return
+
+        for line in self.invoice_line_ids:
+            line.discount = self.global_discount
+            line._compute_totals()
+
 
 
     @api.depends("fp_serial_num")
@@ -82,6 +101,47 @@ class AccountMove(models.Model):
         else:
             self.control_number = None
             self.fiscal_correlative = None
+
+
+
+    @api.depends_context('lang')
+    @api.depends(
+        'invoice_line_ids.currency_rate',
+        'invoice_line_ids.tax_base_amount',
+        'invoice_line_ids.tax_line_id',
+        'invoice_line_ids.price_total',
+        'invoice_line_ids.price_subtotal',
+        'invoice_payment_term_id',
+        'partner_id',
+        'currency_id',
+        'global_discount'
+    )
+    def _compute_tax_totals(self):
+        super()._compute_tax_totals()
+        for invoice in self:
+            if not invoice.tax_totals or invoice.global_discount <= 0:
+                continue
+            
+            aux_key = _("Untaxed Amount")
+
+            invoice.tax_totals["groups_by_subtotal"][aux_key] = invoice.tax_totals["groups_by_subtotal"].get(aux_key, []) + [{
+                "tax_group_name": _("Global Discount"),
+                "tax_group_amount": 10,
+                "tax_group_base_amount": 1,
+                "formatted_tax_group_amount": invoice.currency_id.format(10),
+                "formatted_tax_group_base_amount": invoice.currency_id.format(1),
+                "hide_base_amount": False
+            }]
+
+            if not invoice.tax_totals.get("subtotals"):
+                invoice.tax_totals.update({
+                    "subtotals": [{
+                        "name": aux_key,
+                        "amount": invoice.amount_untaxed,
+                        "formatted_amount": invoice.currency_id.format(invoice.amount_untaxed)
+                    }],
+                    "subtotals_order": [aux_key]
+                })
 
 
     def get_payments_for_fiscal_machine(self):

--- a/models/account_move.py
+++ b/models/account_move.py
@@ -26,6 +26,20 @@ class AccountMove(models.Model):
     num_report_z = fields.Char("Numero de reporte Z", readonly=True)
     global_discount = fields.Float("Global Discount", digits=(12, 2), default=0.0,
         help="Global discount applied to the invoice, this is not a fiscal field")
+    amount_discount = fields.Monetary('Discount', store=True, compute='_compute_amount_discount', readonly=True)
+
+    @api.depends('invoice_line_ids.price_total', 'invoice_line_ids.discount')
+    def _compute_amount_discount(self):
+
+        def get_amount_discount(line):
+            taxes = line.tax_ids
+            amount_base = line.price_unit * line.quantity
+            taxes_amount = [amount_base * tax.amount / 100 for tax in taxes]
+
+            return (sum(taxes_amount) + amount_base) * line.discount / 100
+
+        for invoice in self:
+            invoice.amount_discount = sum(invoice.invoice_line_ids.mapped(get_amount_discount))
 
     @api.onchange("global_discount")
     def _onchange_global_discount(self):
@@ -44,11 +58,11 @@ class AccountMove(models.Model):
             line._compute_totals()
 
 
-
     @api.depends("fp_serial_num")
     def _compute_fiscal_check(self):
         for invoice in self:
             invoice.fiscal_check = bool(invoice.fp_serial_num)
+
 
     @api.onchange('fiscal_check')
     def onchange_fiscal_check(self):
@@ -103,6 +117,7 @@ class AccountMove(models.Model):
             self.fiscal_correlative = None
 
 
+    #TODO: Add tax totals
 
     @api.depends_context('lang')
     @api.depends(
@@ -119,29 +134,26 @@ class AccountMove(models.Model):
     def _compute_tax_totals(self):
         super()._compute_tax_totals()
         for invoice in self:
-            if not invoice.tax_totals or invoice.global_discount <= 0:
+
+            if invoice.amount_discount <= 0:
                 continue
-            
-            aux_key = _("Untaxed Amount")
 
-            invoice.tax_totals["groups_by_subtotal"][aux_key] = invoice.tax_totals["groups_by_subtotal"].get(aux_key, []) + [{
-                "tax_group_name": _("Global Discount"),
-                "tax_group_amount": -10,
-                "tax_group_base_amount": -100,
-                "formatted_tax_group_amount": invoice.currency_id.format(-10),
-                "formatted_tax_group_base_amount": invoice.currency_id.format(-100),
-                "hide_base_amount": False
-            }]
+            vals = [
+                {
+                    "name": _("Untaxed Amount Without Discount"),
+                    "amount": sum(invoice.invoice_line_ids.mapped(lambda l: l.quantity * l.price_unit)),
+                    "formatted_amount": invoice.currency_id.format(sum(invoice.invoice_line_ids.mapped(lambda l: l.quantity * l.price_unit)))
+                },
+                {
+                    "name": _("Global Discount"),
+                    "amount": invoice.amount_discount,
+                    "formatted_amount": invoice.currency_id.format(invoice.amount_discount)
+                }
+            ]
 
-            if not invoice.tax_totals.get("subtotals"):
-                invoice.tax_totals.update({
-                    "subtotals": [{
-                        "name": aux_key,
-                        "amount": invoice.amount_untaxed,
-                        "formatted_amount": invoice.currency_id.format(invoice.amount_untaxed)
-                    }],
-                    "subtotals_order": [aux_key]
-                })
+            invoice.tax_totals["subtotals"] = vals + invoice.tax_totals["subtotals"]
+            invoice.tax_totals["groups_by_subtotal"][_("Global Discount")] = []
+            invoice.tax_totals["groups_by_subtotal"][_("Untaxed Amount Without Discount")] = []
 
 
     def get_payments_for_fiscal_machine(self):

--- a/views/account_move_views.xml
+++ b/views/account_move_views.xml
@@ -15,6 +15,7 @@
         <field name="ticket_ref" attrs="{'invisible': ['|',('move_type', 'in', ['entry', 'in_invoice', 'in_refund']), ('invoice_print_method', '=', 'free_form')]}"/>
         <field name="fp_serial_num" attrs="{'invisible': ['|',('move_type','in',['entry', 'in_invoice', 'in_refund']), ('invoice_print_method', '=', 'free_form')]}" />
         <field name="num_report_z" attrs="{'invisible': ['|',('move_type','in',['entry', 'in_invoice', 'in_refund']), ('invoice_print_method', '=', 'free_form')]}"/>
+        <field name="global_discount"/>
       </field>
     </field>
   </record>

--- a/views/account_move_views.xml
+++ b/views/account_move_views.xml
@@ -17,6 +17,9 @@
         <field name="num_report_z" attrs="{'invisible': ['|',('move_type','in',['entry', 'in_invoice', 'in_refund']), ('invoice_print_method', '=', 'free_form')]}"/>
         <field name="global_discount"/>
       </field>
+      <field name="tax_totals" position="after">
+        <field name="amount_discount" readonly="1"/>
+      </field>
     </field>
   </record>
 


### PR DESCRIPTION
## ✨ Feature: Descuento Global en Facturas

### 📌 Descripción
Este Pull Request implementa la funcionalidad de **Descuento Global** dentro del módulo `tribute_fields`. Permite aplicar un porcentaje de descuento a nivel de factura que se refleja automáticamente en cada línea del documento.

---

### 🧠 Cambios principales

- 🧮 Se agregó el campo `global_discount` al modelo `account.move` con validaciones y lógica de cálculo.
- 🎯 Las líneas de factura actualizan el campo `discount` según el valor del descuento global ingresado.
- 📊 Actualización de los `tax_totals`, incluyendo:
  - "Subtotal sin descuento"
  - "Descuento global"
- 🚫 Validación para evitar valores negativos en `global_discount`.
- 👁️ Campo visible en la vista de factura.
- 🌐 Nuevas traducciones en `i18n/es_VE.po`.

---

### ⚠️ Consideraciones

- El campo `global_discount` **no es fiscal**, sirve para fines contables internos.
- No interfiere con la lógica de impresión fiscal ni con la serialización Z.

---

### ✅ Cómo probar

1. Crear una factura con varias líneas.
2. Ingresar un valor en el campo “Descuento global”.
3. Verificar que cada línea refleje el nuevo porcentaje de descuento.
4. Confirmar que los totales fiscales incluyan los nuevos subtotales.

---

